### PR TITLE
Corrige criação de evento de processo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 Lista de atualizações da Extensão.
 
-## 1.22.5
+## 1.23.1
 
-- Remove código duplicado;
+- Altera snippet de criação de função de formatar data para algo mais simples;
+- Corrige criação de evento de processo quando o nome do processo possuí espaços;
 
 ## 1.23.0
 
@@ -13,6 +14,10 @@ Lista de atualizações da Extensão.
 - Criado o GlobalStorageService para armazenar o último parentDocumentId utilizado;
 - Alterado a ordem dos campos "Manter Versão" e "Criar Nova Versão" para evitar de criar nova versão sem querer;
 - Criado o pacote extensions para melhor organização dos comandos;
+
+## 1.22.5
+
+- Remove código duplicado;
 
 ## 1.22.4
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "fluiggers-fluig-vscode-extension",
-    "version": "1.23.0",
+    "version": "1.23.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "fluiggers-fluig-vscode-extension",
     "displayName": "Fluig - Extensão para Desenvolvimento",
     "description": "Extensão para agilizar o desenvolvimento para o TOTVS Fluig no VS Code",
-    "version": "1.23.0",
+    "version": "1.23.1",
     "publisher": "Fluiggers",
     "icon": "images/icon.png",
     "repository": {

--- a/snippets/javascript.json
+++ b/snippets/javascript.json
@@ -44,9 +44,8 @@
             "        format = \"dd/MM/yyyy\";",
             "    }",
             "",
-            "    var data = java.time.LocalDateTime.now();",
-            "    var formatter = java.time.format.DateTimeFormatter.ofPattern(format);",
-            "    return data.format(formatter);",
+            "    var formatter = new java.text.SimpleDateFormat(format);",
+            "    return formatter.format(new java.util.Date());",
             "}",
             "$0"
         ],

--- a/src/extensions/WorkflowExtension.ts
+++ b/src/extensions/WorkflowExtension.ts
@@ -65,7 +65,7 @@ export class WorkflowExtension {
 
         const processName: string =
             folderUri.path.endsWith(".process")
-                ? folderUri.path.replace(/.*\/(\w+)\.process$/, "$1")
+                ? folderUri.path.replace(/.*\/workflow\/diagrams\/([^.]+).+\.process$/, "$1")
                 : folderUri.path.replace(/.*\/workflow\/scripts\/([^.]+).+\.js$/, "$1");
 
         const eventFilename = `${processName}.${eventName}.js`;

--- a/src/extensions/WorkflowExtension.ts
+++ b/src/extensions/WorkflowExtension.ts
@@ -65,7 +65,7 @@ export class WorkflowExtension {
 
         const processName: string =
             folderUri.path.endsWith(".process")
-                ? folderUri.path.replace(/.*\/workflow\/diagrams\/([^.]+).+\.process$/, "$1")
+                ? folderUri.path.replace(/.*\/workflow\/diagrams\/([^.]+)\.process$/, "$1")
                 : folderUri.path.replace(/.*\/workflow\/scripts\/([^.]+).+\.js$/, "$1");
 
         const eventFilename = `${processName}.${eventName}.js`;


### PR DESCRIPTION
Não era possível criar evento de processo, clicando no processo, quando ele possuía nome com espaços.

Também foi alterado o snippet de formatação de data em backend para algo mais simples.